### PR TITLE
Fortran : Depreciation Calculator 2.1

### DIFF
--- a/Fortran/DepreciationCalculator2.1.f95
+++ b/Fortran/DepreciationCalculator2.1.f95
@@ -1,0 +1,289 @@
+! Depreciation Calculator 2.1
+!   - Date: 2024.04.29
+!
+! This program calculates depreciation using various methods including:
+!   - Straight-Line Method
+!   - Declining Balance Method
+!   - Double Declining Balance Method
+!   - Sum-of-the-Years' Digits Method
+!
+! <Updates>
+! Ver.1     2024.04.20  Initialize with Straight-Line Method
+! Ver.2     2024.04.22  Add other 3 depreciation methods
+!                         - Declining Balance Method
+!                         - Double Declining Balance Method
+!                         - Sum-of-the-Years' Digits Method
+! Ver.2.1   2044.04.29  Refactoring; Divide into
+!                         - SetTableFormats()
+!                         - PrintProgramInfo()
+!                         - PrintDepreciationMethodDetails()
+!                         - GetUserInput()
+!                         - CalculateDefaultDepreciationRate()
+!                         - PrintDepreciationTableHeader()
+!                         - PrintDepreciationTableRow()
+
+MODULE GlobalFormats
+
+    ! Declare global variables for formatting
+    IMPLICIT NONE
+    CHARACTER(LEN=19) :: TableColumnNameFormat
+    CHARACTER(LEN=25) :: TableRowContentFormat
+    CHARACTER(LEN=22) :: TableTitleFormatWithRate
+    CHARACTER(LEN=10) :: TableTitleFormatWithoutRate
+
+END MODULE GlobalFormats
+
+PROGRAM DepreciationCalculator2
+
+    USE GlobalFormats
+
+    IMPLICIT NONE
+    DOUBLE PRECISION :: InitialCost, SalvageValue, UsefulLife, DepreciationRate
+    INTEGER :: Year
+
+    ! Set column and row formatting
+    CALL SetTableFormats(TableColumnNameFormat, TableRowContentFormat, &
+                         TableTitleFormatWithRate, TableTitleFormatWithoutRate)
+
+    ! Display program information
+    CALL PrintProgramInfo()
+
+    ! Notification of specific details
+    CALL PrintDepreciationMethodDetails()
+
+    ! Get user input
+    CALL GetUserInput(InitialCost, SalvageValue, UsefulLife, DepreciationRate)
+
+    ! Set default value of the depreciation rate for DB method
+    CALL CalculateDefaultDepreciationRate(DepreciationRate, UsefulLife)
+
+    ! Call the custom functions to calculate depreciation
+    CALL CalculateStraightLine(InitialCost, SalvageValue, UsefulLife)
+    CALL CalculateDecliningBalance(InitialCost, SalvageValue, UsefulLife, DepreciationRate)
+    CALL CalculateDoubleDecliningBalance(InitialCost, SalvageValue, UsefulLife)
+    CALL CalculateSYD(InitialCost, SalvageValue, UsefulLife)
+
+CONTAINS
+
+    SUBROUTINE SetTableFormats(TableColumnNameFormat, TableRowContentFormat, &
+                               TableTitleFormatWithRate, TableTitleFormatWithoutRate)
+
+        IMPLICIT NONE
+        CHARACTER(*), INTENT(OUT) :: TableColumnNameFormat, TableRowContentFormat, &
+                                     TableTitleFormatWithRate, TableTitleFormatWithoutRate
+
+        ! Set column and row formatting
+        TableColumnNameFormat = "(A6, A16, A16, A16)"
+        TableRowContentFormat = "(I6, F16.2, F16.2, F16.2)"
+        TableTitleFormatWithRate = "(A, A, A, A, F5.2, A/)"
+        TableTitleFormatWithoutRate = "(A, A, A/)"
+
+    END SUBROUTINE SetTableFormats
+
+    SUBROUTINE PrintProgramInfo()
+
+        IMPLICIT NONE
+
+        ! Display program information
+        WRITE(*, '(A)', ADVANCE='NO')  "Depreciation Calculator Ver.2.1"
+        WRITE(*, '(A/)') " (2024.04.29)"
+
+    END SUBROUTINE PrintProgramInfo
+
+    SUBROUTINE PrintDepreciationMethodDetails()
+
+        ! Print the notification about declining balance method and salvage value
+        WRITE(*, '(A)')  "※ In declining balance method and double declining balance depreciation, "
+        WRITE(*, '(A/)') "  the salvage value is not recognized in the calculation of the depreciation base."
+
+    END SUBROUTINE PrintDepreciationMethodDetails
+
+    SUBROUTINE GetUserInput(InitialCost, SalvageValue, UsefulLife, DepreciationRate)
+
+        IMPLICIT NONE
+        DOUBLE PRECISION, INTENT(OUT) :: InitialCost, SalvageValue, UsefulLife, DepreciationRate
+
+        ! Get user input
+        WRITE(*, '(A)', ADVANCE='NO') "  Enter the initial cost of the asset           : "
+        READ *, InitialCost
+
+        WRITE(*, '(A)', ADVANCE='NO') "  Enter the salvage value of the asset          : "
+        READ *, SalvageValue
+
+        WRITE(*, '(A)', ADVANCE='NO') "  Enter the useful life of the asset (in years) : "
+        READ *, UsefulLife
+
+        WRITE(*, '(A)')               "  Enter the depreciation rate(%)"
+        WRITE(*, '(A)', ADVANCE='NO') "    (Default: 2 / useful life, ≒ DDB)           : "
+        READ *, DepreciationRate
+
+        WRITE(*, '(A)') ""
+
+    END SUBROUTINE GetUserInput
+
+    SUBROUTINE CalculateDefaultDepreciationRate(DepreciationRate, UsefulLife)
+
+        IMPLICIT NONE
+        DOUBLE PRECISION, INTENT(INOUT) :: DepreciationRate
+        DOUBLE PRECISION, INTENT(IN) :: UsefulLife
+    
+        IF (DepreciationRate == 0.0) THEN
+            DepreciationRate = (2 / UsefulLife) * 100
+        END IF
+
+    END SUBROUTINE CalculateDefaultDepreciationRate
+
+    SUBROUTINE PrintDepreciationTableHeader(MethodName, DepreciationRate)
+
+        IMPLICIT NONE
+        CHARACTER(*), INTENT(IN) :: MethodName
+        DOUBLE PRECISION, OPTIONAL, INTENT(IN) :: DepreciationRate
+
+        ! Print the header for the specified depreciation method
+        IF (PRESENT(DepreciationRate)) THEN
+            WRITE(*, TableTitleFormatWithRate) "<", MethodName, ">", &
+                                               " (Rate: ", DepreciationRate, "%)"
+        ELSE
+            WRITE(*, TableTitleFormatWithoutRate) "<", MethodName, ">"
+        END IF
+        WRITE(*, TableColumnNameFormat) "Year", "Depreciation", "Accumulated", "Book"
+        WRITE(*, TableColumnNameFormat) "", "Expense", "Depreciation", "Value"
+
+    END SUBROUTINE PrintDepreciationTableHeader
+
+    SUBROUTINE PrintDepreciationTableRow(Year, DepreciationExpense, &
+                                         AccumulatedDepreciation, BookValue)
+
+        IMPLICIT NONE
+        INTEGER, INTENT(IN) :: Year
+        DOUBLE PRECISION, INTENT(IN) :: DepreciationExpense, AccumulatedDepreciation, BookValue
+
+        ! Print the row content for each year
+        WRITE(*, TableRowContentFormat) Year, DepreciationExpense, &
+                                        AccumulatedDepreciation, BookValue
+
+    END SUBROUTINE PrintDepreciationTableRow
+
+    SUBROUTINE CalculateStraightLine(InitialCost, SalvageValue, UsefulLife)
+
+        IMPLICIT NONE
+        DOUBLE PRECISION, INTENT(IN) :: InitialCost, SalvageValue, UsefulLife
+        DOUBLE PRECISION :: DepreciationExpense, AccumulatedDepreciation, BookValue
+
+        ! Initialize accumulatedDepreciation and bookValue
+        AccumulatedDepreciation = 0.0
+        BookValue = InitialCost
+
+        ! Calculate and print depreciation for each year
+        CALL PrintDepreciationTableHeader("Straight-Line Method")
+        DO Year = 1, INT(UsefulLife)
+            DepreciationExpense = (InitialCost - SalvageValue) / UsefulLife
+            AccumulatedDepreciation = AccumulatedDepreciation + DepreciationExpense
+            BookValue = BookValue - DepreciationExpense
+            CALL PrintDepreciationTableRow(Year, DepreciationExpense, &
+                                           AccumulatedDepreciation, BookValue)
+        END DO
+        WRITE(*, '(A)') ""
+
+    END SUBROUTINE CalculateStraightLine
+
+    SUBROUTINE CalculateDecliningBalance(InitialCost, SalvageValue, &
+                                         UsefulLife, DepreciationRate)
+
+        IMPLICIT NONE
+        DOUBLE PRECISION, INTENT(IN) :: InitialCost, SalvageValue, &
+                                        UsefulLife, DepreciationRate
+        DOUBLE PRECISION :: DepreciationExpense, AccumulatedDepreciation, BookValue
+
+        ! Initialize accumulatedDepreciation and bookValue
+        AccumulatedDepreciation = 0.0
+        BookValue = InitialCost
+
+        ! Calculate and print depreciation for each year
+        CALL PrintDepreciationTableHeader("Declining Balance Method", DepreciationRate)
+        DO Year = 1, INT(UsefulLife)
+            IF (BookValue * (1 - DepreciationRate / 100) >= SalvageValue) THEN
+                DepreciationExpense = BookValue * DepreciationRate / 100
+                AccumulatedDepreciation = AccumulatedDepreciation + DepreciationExpense
+                BookValue = BookValue - DepreciationExpense
+            ELSE
+                BookValue = SalvageValue
+                DepreciationExpense = (InitialCost - SalvageValue) - AccumulatedDepreciation
+                AccumulatedDepreciation = InitialCost - SalvageValue
+            END IF
+
+            CALL PrintDepreciationTableRow(Year, DepreciationExpense, &
+                                           AccumulatedDepreciation, BookValue)
+
+            IF (BookValue <= SalvageValue) THEN
+                EXIT
+            END IF
+        END DO
+        WRITE(*, '(A)') ""
+
+    END SUBROUTINE CalculateDecliningBalance
+
+    SUBROUTINE CalculateDoubleDecliningBalance(InitialCost, SalvageValue, UsefulLife)
+
+        IMPLICIT NONE
+        DOUBLE PRECISION, INTENT(IN) :: InitialCost, SalvageValue, UsefulLife
+        DOUBLE PRECISION :: DepreciationRate, DepreciationExpense, &
+                            AccumulatedDepreciation, BookValue
+
+        ! Initialize accumulatedDepreciation and bookValue
+        AccumulatedDepreciation = 0.0
+        BookValue = InitialCost
+        DepreciationRate = (2 / UsefulLife) * 100
+
+        ! Calculate and print depreciation for each year
+        CALL PrintDepreciationTableHeader("Double Declining Balance Method", DepreciationRate)
+        DO Year = 1, INT(UsefulLife)
+            IF (BookValue * (1 - DepreciationRate / 100) >= SalvageValue) THEN
+                DepreciationExpense = BookValue * DepreciationRate / 100
+                AccumulatedDepreciation = AccumulatedDepreciation + DepreciationExpense
+                BookValue = BookValue - DepreciationExpense
+            ELSE
+                BookValue = SalvageValue
+                DepreciationExpense = (InitialCost - SalvageValue) - AccumulatedDepreciation
+                AccumulatedDepreciation = InitialCost - SalvageValue
+            END IF
+
+            CALL PrintDepreciationTableRow(Year, DepreciationExpense, &
+                                           AccumulatedDepreciation, BookValue)
+
+            IF (BookValue <= SalvageValue) THEN
+                EXIT
+            END IF
+        END DO
+        WRITE(*, '(A)') ""
+
+    END SUBROUTINE CalculateDoubleDecliningBalance
+
+    SUBROUTINE CalculateSYD(InitialCost, SalvageValue, UsefulLife)
+
+        IMPLICIT NONE
+        DOUBLE PRECISION, INTENT(IN) :: InitialCost, SalvageValue, UsefulLife
+        DOUBLE PRECISION :: DepreciationExpense, AccumulatedDepreciation, BookValue
+        INTEGER :: SumOfYears
+
+        ! Calculate the sum of the years' digits
+        SumOfYears = UsefulLife * (UsefulLife + 1) / 2
+
+        ! Initialize accumulatedDepreciation and bookValue
+        AccumulatedDepreciation = 0.0
+        BookValue = InitialCost
+
+        ! Calculate and print depreciation for each year
+        CALL PrintDepreciationTableHeader("Sum-of-the-Years' Digits Method")
+        DO Year = 1, INT(UsefulLife)
+            DepreciationExpense = (InitialCost - SalvageValue) * (UsefulLife - Year + 1) / SumOfYears
+            AccumulatedDepreciation = AccumulatedDepreciation + DepreciationExpense
+            BookValue = BookValue - DepreciationExpense
+            CALL PrintDepreciationTableRow(Year, DepreciationExpense, &
+                                           AccumulatedDepreciation, BookValue)
+        END DO
+        WRITE(*, '(A)') ""
+
+    END SUBROUTINE CalculateSYD
+
+END PROGRAM DepreciationCalculator2

--- a/Fortran/DepreciationCalculator2.1.f95
+++ b/Fortran/DepreciationCalculator2.1.f95
@@ -107,7 +107,8 @@ CONTAINS
         WRITE(*, '(A)', ADVANCE='NO') "  Enter the initial cost of the asset           : "
         READ *, InitialCost
 
-        WRITE(*, '(A)', ADVANCE='NO') "  Enter the salvage value of the asset          : "
+        WRITE(*, '(A)')               "  Enter the salvage value of the asset"
+        WRITE(*, '(A)', ADVANCE='NO') "    (or the memorandum value)                   : "
         READ *, SalvageValue
 
         WRITE(*, '(A)', ADVANCE='NO') "  Enter the useful life of the asset (in years) : "

--- a/Fortran/README.md
+++ b/Fortran/README.md
@@ -373,6 +373,34 @@
     END PROGRAM DepreciationCalculator2
     ```
     ```fortran
+        SUBROUTINE CalculateStraightLine(InitialCost, SalvageValue, UsefulLife)
+
+            IMPLICIT NONE
+
+            DOUBLE PRECISION, INTENT(IN) :: InitialCost, SalvageValue, UsefulLife
+            DOUBLE PRECISION :: DepreciationExpense, AccumulatedDepreciation, BookValue
+
+            ! Initialize accumulatedDepreciation and bookValue
+            AccumulatedDepreciation = 0.0
+            BookValue = InitialCost
+
+            ! Print header
+            WRITE(*, '(A, /)') "<Straight-Line Method>"
+            WRITE(*, ColumnNameFormat) "Year", "Depreciation", "Accumulated", "Book"
+            WRITE(*, ColumnNameFormat) "", "Expense", "Depreciation", "Value"
+
+            ! Calculate and print depreciation for each year
+            DO Year = 1, INT(UsefulLife)
+                DepreciationExpense = (InitialCost - SalvageValue) / UsefulLife
+                AccumulatedDepreciation = AccumulatedDepreciation + DepreciationExpense
+                BookValue = BookValue - DepreciationExpense
+                WRITE(*, RowContentFormat) Year, DepreciationExpense, AccumulatedDepreciation, BookValue
+            END DO
+            WRITE(*, '(A)') ""
+
+        END SUBROUTINE CalculateStraightLine
+    ```
+    ```fortran
         SUBROUTINE CalculateDecliningBalance(InitialCost, SalvageValue, UsefulLife, DepreciationRate)
 
             IMPLICIT NONE

--- a/Fortran/README.md
+++ b/Fortran/README.md
@@ -3,10 +3,291 @@
 
 ### \<List>
 
+- [Depreciation Calculator 2.1 (2024.04.29)](#depreciation-calculator-21-20240429)
 - [Depreciation Calculator 2 (2024.04.22)](#depreciation-calculator-2-20240422)
 - [Depreciation Calculator (2024.04.20)](#depreciation-calculator-20240420)
 - [Compound Interest Calculator 2 (2023.12.16)](#compound-interest-calculator-2-20231216)
 - [Compound Interest Calculator (2023.12.07)](#compound-interest-calculator-20231207)
+
+
+## [Depreciation Calculator 2.1 (2024.04.29)](#list)
+
+- Refactoring : Divide into 7 subroutines
+  - `SetTableFormats()` `PrintProgramInfo()` `PrintDepreciationMethodDetails()` `GetUserInput()` `CalculateDefaultDepreciationRate()` `PrintDepreciationTableHeader()` `PrintDepreciationTableRow()`
+- Code and Output
+  <details>
+    <summary>Code : DepreciationCalculator2.1.f95 (Only mainly updated parts)</summary>
+
+  ```fortran
+  MODULE GlobalFormats
+
+      ! Declare global variables for formatting
+      IMPLICIT NONE
+      CHARACTER(LEN=19) :: TableColumnNameFormat
+      CHARACTER(LEN=25) :: TableRowContentFormat
+      CHARACTER(LEN=22) :: TableTitleFormatWithRate
+      CHARACTER(LEN=10) :: TableTitleFormatWithoutRate
+
+  END MODULE GlobalFormats
+  ```
+  ```fortran
+  PROGRAM DepreciationCalculator2
+
+      USE GlobalFormats
+
+      IMPLICIT NONE
+      DOUBLE PRECISION :: InitialCost, SalvageValue, UsefulLife, DepreciationRate
+      INTEGER :: Year
+
+      ! Set column and row formatting
+      CALL SetTableFormats(TableColumnNameFormat, TableRowContentFormat, &
+                          TableTitleFormatWithRate, TableTitleFormatWithoutRate)
+
+      ! Display program information
+      CALL PrintProgramInfo()
+
+      ! Notification of specific details
+      CALL PrintDepreciationMethodDetails()
+
+      ! Get user input
+      CALL GetUserInput(InitialCost, SalvageValue, UsefulLife, DepreciationRate)
+
+      ! Set default value of the depreciation rate for DB method
+      CALL CalculateDefaultDepreciationRate(DepreciationRate, UsefulLife)
+
+      ! Call the custom functions to calculate depreciation
+      ……
+
+  CONTAINS
+
+      SUBROUTINE SetTableFormats(TableColumnNameFormat, TableRowContentFormat, &
+                                TableTitleFormatWithRate, TableTitleFormatWithoutRate)
+      ……
+
+      SUBROUTINE PrintProgramInfo()
+      ……
+
+      SUBROUTINE PrintDepreciationMethodDetails()
+      ……
+
+      SUBROUTINE GetUserInput(InitialCost, SalvageValue, UsefulLife, DepreciationRate)
+      ……
+
+      SUBROUTINE CalculateDefaultDepreciationRate(DepreciationRate, UsefulLife)
+      ……
+
+      SUBROUTINE PrintDepreciationTableHeader(MethodName, DepreciationRate)
+      ……
+
+      SUBROUTINE PrintDepreciationTableRow(Year, DepreciationExpense, &
+                                          AccumulatedDepreciation, BookValue)
+      ……
+
+      SUBROUTINE CalculateStraightLine(InitialCost, SalvageValue, UsefulLife)
+      ……
+
+      SUBROUTINE CalculateDecliningBalance(InitialCost, SalvageValue, &
+                                          UsefulLife, DepreciationRate)
+      ……
+
+      SUBROUTINE CalculateDoubleDecliningBalance(InitialCost, SalvageValue, UsefulLife)
+      ……
+
+      SUBROUTINE CalculateSYD(InitialCost, SalvageValue, UsefulLife)
+      ……
+
+  END PROGRAM DepreciationCalculator2
+  ```
+  ```fortran
+      SUBROUTINE SetTableFormats(TableColumnNameFormat, TableRowContentFormat, &
+                                TableTitleFormatWithRate, TableTitleFormatWithoutRate)
+
+          IMPLICIT NONE
+          CHARACTER(*), INTENT(OUT) :: TableColumnNameFormat, TableRowContentFormat, &
+                                      TableTitleFormatWithRate, TableTitleFormatWithoutRate
+
+          ! Set column and row formatting
+          TableColumnNameFormat = "(A6, A16, A16, A16)"
+          TableRowContentFormat = "(I6, F16.2, F16.2, F16.2)"
+          TableTitleFormatWithRate = "(A, A, A, A, F5.2, A/)"
+          TableTitleFormatWithoutRate = "(A, A, A/)"
+
+      END SUBROUTINE SetTableFormats
+  ```
+  ```fortran
+      SUBROUTINE PrintProgramInfo()
+
+          IMPLICIT NONE
+
+          ! Display program information
+          WRITE(*, '(A)', ADVANCE='NO')  "Depreciation Calculator Ver.2.1"
+          WRITE(*, '(A/)') " (2024.04.29)"
+
+      END SUBROUTINE PrintProgramInfo
+  ```
+  ```fortran
+      SUBROUTINE PrintDepreciationMethodDetails()
+
+          ! Print the notification about declining balance method and salvage value
+          WRITE(*, '(A)')  "※ In declining balance method and double declining balance depreciation, "
+          WRITE(*, '(A/)') "  the salvage value is not recognized in the calculation of the depreciation base."
+
+      END SUBROUTINE PrintDepreciationMethodDetails
+  ```
+  ```fortran
+      SUBROUTINE GetUserInput(InitialCost, SalvageValue, UsefulLife, DepreciationRate)
+
+          IMPLICIT NONE
+          DOUBLE PRECISION, INTENT(OUT) :: InitialCost, SalvageValue, UsefulLife, DepreciationRate
+
+          ! Get user input
+          WRITE(*, '(A)', ADVANCE='NO') "  Enter the initial cost of the asset           : "
+          READ *, InitialCost
+
+          WRITE(*, '(A)', ADVANCE='NO') "  Enter the salvage value of the asset          : "
+          READ *, SalvageValue
+
+          WRITE(*, '(A)', ADVANCE='NO') "  Enter the useful life of the asset (in years) : "
+          READ *, UsefulLife
+
+          WRITE(*, '(A)')               "  Enter the depreciation rate(%)"
+          WRITE(*, '(A)', ADVANCE='NO') "    (Default: 2 / useful life, ≒ DDB)           : "
+          READ *, DepreciationRate
+
+          WRITE(*, '(A)') ""
+
+      END SUBROUTINE GetUserInput
+  ```
+  ```fortran
+      SUBROUTINE CalculateDefaultDepreciationRate(DepreciationRate, UsefulLife)
+
+          IMPLICIT NONE
+          DOUBLE PRECISION, INTENT(INOUT) :: DepreciationRate
+          DOUBLE PRECISION, INTENT(IN) :: UsefulLife
+      
+          IF (DepreciationRate == 0.0) THEN
+              DepreciationRate = (2 / UsefulLife) * 100
+          END IF
+
+      END SUBROUTINE CalculateDefaultDepreciationRate
+  ```
+  ```fortran
+      SUBROUTINE PrintDepreciationTableHeader(MethodName, DepreciationRate)
+
+          IMPLICIT NONE
+          CHARACTER(*), INTENT(IN) :: MethodName
+          DOUBLE PRECISION, OPTIONAL, INTENT(IN) :: DepreciationRate
+
+          ! Print the header for the specified depreciation method
+          IF (PRESENT(DepreciationRate)) THEN
+              WRITE(*, TableTitleFormatWithRate) "<", MethodName, ">", &
+                                                " (Rate: ", DepreciationRate, "%)"
+          ELSE
+              WRITE(*, TableTitleFormatWithoutRate) "<", MethodName, ">"
+          END IF
+          WRITE(*, TableColumnNameFormat) "Year", "Depreciation", "Accumulated", "Book"
+          WRITE(*, TableColumnNameFormat) "", "Expense", "Depreciation", "Value"
+
+      END SUBROUTINE PrintDepreciationTableHeader
+  ```
+  ```fortran
+      SUBROUTINE PrintDepreciationTableRow(Year, DepreciationExpense, &
+                                          AccumulatedDepreciation, BookValue)
+
+          IMPLICIT NONE
+          INTEGER, INTENT(IN) :: Year
+          DOUBLE PRECISION, INTENT(IN) :: DepreciationExpense, AccumulatedDepreciation, BookValue
+
+          ! Print the row content for each year
+          WRITE(*, TableRowContentFormat) Year, DepreciationExpense, &
+                                          AccumulatedDepreciation, BookValue
+
+      END SUBROUTINE PrintDepreciationTableRow
+  ```
+  ```fortran
+      SUBROUTINE CalculateStraightLine(InitialCost, SalvageValue, UsefulLife)
+
+          ……
+
+          ! Calculate and print depreciation for each year
+          CALL PrintDepreciationTableHeader("Straight-Line Method")
+          DO Year = 1, INT(UsefulLife)
+              ……
+              CALL PrintDepreciationTableRow(Year, DepreciationExpense, &
+                                            AccumulatedDepreciation, BookValue)
+          END DO
+          ……
+
+      END SUBROUTINE CalculateStraightLine
+  ```
+  ```fortran
+      SUBROUTINE CalculateDecliningBalance(InitialCost, SalvageValue, &
+                                          UsefulLife, DepreciationRate)
+
+          ……
+
+          ! Calculate and print depreciation for each year
+          CALL PrintDepreciationTableHeader("Declining Balance Method", DepreciationRate)
+          DO Year = 1, INT(UsefulLife)
+              ……
+
+              CALL PrintDepreciationTableRow(Year, DepreciationExpense, &
+                                            AccumulatedDepreciation, BookValue)
+
+              ……
+          END DO
+          ……
+
+      END SUBROUTINE CalculateDecliningBalance
+  ```
+  ```fortran
+      SUBROUTINE CalculateDoubleDecliningBalance(InitialCost, SalvageValue, UsefulLife)
+
+          ……
+
+          ! Calculate and print depreciation for each year
+          CALL PrintDepreciationTableHeader("Double Declining Balance Method", DepreciationRate)
+          DO Year = 1, INT(UsefulLife)
+              ……
+
+              CALL PrintDepreciationTableRow(Year, DepreciationExpense, &
+                                            AccumulatedDepreciation, BookValue)
+
+              ……
+          END DO
+          ……
+
+      END SUBROUTINE CalculateDoubleDecliningBalance
+  ```
+  ```fortran
+      SUBROUTINE CalculateSYD(InitialCost, SalvageValue, UsefulLife)
+
+          ……
+
+          ! Calculate and print depreciation for each year
+          CALL PrintDepreciationTableHeader("Sum-of-the-Years' Digits Method")
+          DO Year = 1, INT(UsefulLife)
+              ……
+              CALL PrintDepreciationTableRow(Year, DepreciationExpense, &
+                                            AccumulatedDepreciation, BookValue)
+          END DO
+          ……
+
+      END SUBROUTINE CalculateSYD
+  ```
+  </details>
+  <details open="">
+    <summary>Output</summary>
+
+  ```fortran
+  Depreciation Calculator Ver.2.1 (2024.04.29)
+
+  ※ In declining balance method and double declining balance depreciation, 
+    the salvage value is not recognized in the calculation of the depreciation base.
+
+    Enter the initial cost of the asset           : ……
+  ```
+  </details>
 
 
 ## [Depreciation Calculator 2 (2024.04.22)](#list)

--- a/Fortran/README.md
+++ b/Fortran/README.md
@@ -41,7 +41,7 @@
 
       ! Set column and row formatting
       CALL SetTableFormats(TableColumnNameFormat, TableRowContentFormat, &
-                          TableTitleFormatWithRate, TableTitleFormatWithoutRate)
+                           TableTitleFormatWithRate, TableTitleFormatWithoutRate)
 
       ! Display program information
       CALL PrintProgramInfo()
@@ -61,7 +61,7 @@
   CONTAINS
 
       SUBROUTINE SetTableFormats(TableColumnNameFormat, TableRowContentFormat, &
-                                TableTitleFormatWithRate, TableTitleFormatWithoutRate)
+                                 TableTitleFormatWithRate, TableTitleFormatWithoutRate)
       ……
 
       SUBROUTINE PrintProgramInfo()
@@ -80,14 +80,14 @@
       ……
 
       SUBROUTINE PrintDepreciationTableRow(Year, DepreciationExpense, &
-                                          AccumulatedDepreciation, BookValue)
+                                           AccumulatedDepreciation, BookValue)
       ……
 
       SUBROUTINE CalculateStraightLine(InitialCost, SalvageValue, UsefulLife)
       ……
 
       SUBROUTINE CalculateDecliningBalance(InitialCost, SalvageValue, &
-                                          UsefulLife, DepreciationRate)
+                                           UsefulLife, DepreciationRate)
       ……
 
       SUBROUTINE CalculateDoubleDecliningBalance(InitialCost, SalvageValue, UsefulLife)
@@ -100,11 +100,11 @@
   ```
   ```fortran
       SUBROUTINE SetTableFormats(TableColumnNameFormat, TableRowContentFormat, &
-                                TableTitleFormatWithRate, TableTitleFormatWithoutRate)
+                                 TableTitleFormatWithRate, TableTitleFormatWithoutRate)
 
           IMPLICIT NONE
           CHARACTER(*), INTENT(OUT) :: TableColumnNameFormat, TableRowContentFormat, &
-                                      TableTitleFormatWithRate, TableTitleFormatWithoutRate
+                                       TableTitleFormatWithRate, TableTitleFormatWithoutRate
 
           ! Set column and row formatting
           TableColumnNameFormat = "(A6, A16, A16, A16)"
@@ -144,7 +144,8 @@
           WRITE(*, '(A)', ADVANCE='NO') "  Enter the initial cost of the asset           : "
           READ *, InitialCost
 
-          WRITE(*, '(A)', ADVANCE='NO') "  Enter the salvage value of the asset          : "
+          WRITE(*, '(A)')               "  Enter the salvage value of the asset"
+          WRITE(*, '(A)', ADVANCE='NO') "    (or the memorandum value)                   : "
           READ *, SalvageValue
 
           WRITE(*, '(A)', ADVANCE='NO') "  Enter the useful life of the asset (in years) : "
@@ -181,7 +182,7 @@
           ! Print the header for the specified depreciation method
           IF (PRESENT(DepreciationRate)) THEN
               WRITE(*, TableTitleFormatWithRate) "<", MethodName, ">", &
-                                                " (Rate: ", DepreciationRate, "%)"
+                                                 " (Rate: ", DepreciationRate, "%)"
           ELSE
               WRITE(*, TableTitleFormatWithoutRate) "<", MethodName, ">"
           END IF
@@ -192,7 +193,7 @@
   ```
   ```fortran
       SUBROUTINE PrintDepreciationTableRow(Year, DepreciationExpense, &
-                                          AccumulatedDepreciation, BookValue)
+                                           AccumulatedDepreciation, BookValue)
 
           IMPLICIT NONE
           INTEGER, INTENT(IN) :: Year
@@ -214,7 +215,7 @@
           DO Year = 1, INT(UsefulLife)
               ……
               CALL PrintDepreciationTableRow(Year, DepreciationExpense, &
-                                            AccumulatedDepreciation, BookValue)
+                                             AccumulatedDepreciation, BookValue)
           END DO
           ……
 
@@ -222,7 +223,7 @@
   ```
   ```fortran
       SUBROUTINE CalculateDecliningBalance(InitialCost, SalvageValue, &
-                                          UsefulLife, DepreciationRate)
+                                           UsefulLife, DepreciationRate)
 
           ……
 
@@ -232,7 +233,7 @@
               ……
 
               CALL PrintDepreciationTableRow(Year, DepreciationExpense, &
-                                            AccumulatedDepreciation, BookValue)
+                                             AccumulatedDepreciation, BookValue)
 
               ……
           END DO
@@ -251,7 +252,7 @@
               ……
 
               CALL PrintDepreciationTableRow(Year, DepreciationExpense, &
-                                            AccumulatedDepreciation, BookValue)
+                                             AccumulatedDepreciation, BookValue)
 
               ……
           END DO
@@ -269,7 +270,7 @@
           DO Year = 1, INT(UsefulLife)
               ……
               CALL PrintDepreciationTableRow(Year, DepreciationExpense, &
-                                            AccumulatedDepreciation, BookValue)
+                                             AccumulatedDepreciation, BookValue)
           END DO
           ……
 
@@ -285,7 +286,24 @@
   ※ In declining balance method and double declining balance depreciation, 
     the salvage value is not recognized in the calculation of the depreciation base.
 
-    Enter the initial cost of the asset           : ……
+    Enter the initial cost of the asset           : 11000
+    Enter the salvage value of the asset
+      (or the memorandum value)                   : 1000
+    Enter the useful life of the asset (in years) : 5
+    Enter the depreciation rate(%)
+      (Default: 2 / useful life, ≒ DDB)           : 50
+
+  <Straight-Line Method>
+
+   Year    Depreciation     Accumulated            Book
+                Expense    Depreciation           Value
+      1         2000.00         2000.00         9000.00
+      2         2000.00         4000.00         7000.00
+      3         2000.00         6000.00         5000.00
+      4         2000.00         8000.00         3000.00
+      5         2000.00        10000.00         1000.00
+
+  ……
   ```
   </details>
 

--- a/Fortran/README.md
+++ b/Fortran/README.md
@@ -297,8 +297,8 @@
   - Double Declining Balance Method
   - Sum-of-the-Years' Digits Method
 - Future Improvements
-  - Calculation of depreciation adjustment related with tax accounting
-  - Consideration of memorandum value
+  - ~~Calculation of depreciation adjustment related with tax accounting~~
+  - ~~Consideration of memorandum value~~
 - Code and Output
   <details>
     <summary>Code : DepreciationCalculator2.f95</summary>
@@ -575,7 +575,7 @@
 - Calculate depreciation only using the straight-line method
 - Future Improvements
   - Add various methods of depreciation  
-    : Declining Balance Method, Accelerated Depreciation Method, Sum-of-the-Years’ Digits Method, etc.
+    : Declining Balance Method, Accelerated Depreciation Method, Sum-of-the-Years’ Digits Method, etc. → [Done](#depreciation-calculator-2-20240422)
 - Code and Output
   <details>
     <summary>Code : DepreciationCalculator.f95</summary>

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Being Great Gatsby with legacy language programming
 
 ## [Fortran](/Fortran/)
 
+  - [Depreciation Calculator 2.1 (2024.04.29)](/Fortran/README.md#depreciation-calculator-21-20240429)
   - [Depreciation Calculator 2 (2024.04.22)](/Fortran/README.md#depreciation-calculator-2-20240422)
   - [Depreciation Calculator (2024.04.20)](/Fortran/README.md#depreciation-calculator-20240420)
   - [Compound Interest Calculator 2 (2023.12.16)](/Fortran/README.md#compound-interest-calculator-2-20231216)


### PR DESCRIPTION
## Refactoring

- Divide into
  - `SetTableFormats()`
  - `PrintProgramInfo()`
  - `PrintDepreciationMethodDetails()`
  - `GetUserInput()`
  - `CalculateDefaultDepreciationRate()`
  - `PrintDepreciationTableHeader()`
  - `PrintDepreciationTableRow()`

## Result

  ```fortran
  Depreciation Calculator Ver.2.1 (2024.04.29)
  
  ※ In declining balance method and double declining balance depreciation, 
    the salvage value is not recognized in the calculation of the depreciation base.
  
    Enter the initial cost of the asset           : ……
  ```